### PR TITLE
Adding a child and updating it clears root's dimension

### DIFF
--- a/src/__tests__/solver/LayoutSolver.test.ts
+++ b/src/__tests__/solver/LayoutSolver.test.ts
@@ -80,4 +80,58 @@ describe(LayoutSolver, () => {
 
         expect(height.value()).toBe(100);
     });
+
+    test(`adding and modifying children`, () => {
+        const tree = LayoutViewTree.fromJSON({
+            name: 'root',
+            rect: [0, 0, 100, 100] // note: this doesn't matter wrt the solver.
+        });
+        
+        const solver = new LayoutSolver(tree); 
+
+        const newRectJSON : ILayoutViewTree.JSON = { name: "c"
+                            , rect: [25, 25, 75, 75]
+                            , children: []
+                            };
+
+        const retrievedRoot = solver.getView('root');
+        const retrievedRootJSON = retrievedRoot.json;
+        
+        expect(retrievedRootJSON.children);
+
+        retrievedRootJSON.children.push(newRectJSON);
+
+        const view = LayoutViewTree.fromJSON(retrievedRootJSON);
+        const newSolver = new LayoutSolver(view);
+
+        const [left, top, right, bottom] = newSolver.getVariables(
+            `c.left`,
+            `c.top`, 
+            `c.right`,
+            `c.bottom`
+        ) as Array<Variable>;
+
+        debugger
+
+        newSolver.addEditVariable(left, Strength.strong);
+        newSolver.suggestValue(left, 50);
+
+        newSolver.addEditVariable(top, Strength.strong);
+        newSolver.suggestValue(top, 50);
+
+        newSolver.addEditVariable(right, Strength.strong);
+        newSolver.suggestValue(right, 80);
+
+        newSolver.addEditVariable(bottom, Strength.strong);
+        newSolver.suggestValue(bottom, 80);
+
+        newSolver.updateVariables();
+        newSolver.updateView();
+
+        const updatedRoot = newSolver.getView('root') as ILayoutViewTree
+
+        expect(updatedRoot.rect).toEqual([0, 0, 100, 100]);
+        // is actually [0,0,0,0]
+
+    });
 });

--- a/src/__tests__/solver/LayoutSolver.test.ts
+++ b/src/__tests__/solver/LayoutSolver.test.ts
@@ -81,6 +81,25 @@ describe(LayoutSolver, () => {
         expect(height.value()).toBe(100);
     });
 
+    test(`modifying variables`, () => {
+        const tree = LayoutViewTree.fromJSON({
+            name: 'root',
+            rect: [0, 0, 100, 100] // note: this doesn't matter wrt the solver.
+        });
+        
+        const solver = new LayoutSolver(tree);
+        const [top, bottom, height] = solver.getVariables(
+            'root.top', 
+            'root.bottom', 
+            'root.height'
+        ) as Array<Variable>;
+
+        top.setValue(10);
+        
+        solver.updateView();
+        expect(solver.root.json.rect).toBe([0, 10, 100, 100]);
+    })
+
     test(`adding and modifying children`, () => {
         const tree = LayoutViewTree.fromJSON({
             name: 'root',

--- a/src/__tests__/views/LayoutViewTree.test.ts
+++ b/src/__tests__/views/LayoutViewTree.test.ts
@@ -89,6 +89,20 @@ describe(LayoutViewTree, () => {
             ]
         });
 
+        const views = Array.from(view)
+        expect(views).toHaveLength(3)
+    });
+
+    test(`implements Iterable.`, () => {
+        const view = LayoutViewTree.fromJSON({
+            name: "root",
+            rect: [0, 0, 100, 100],
+            children: [
+                {name: "a", rect: [0, 0, 50, 50], children: []},
+                {name: "b", rect: [50, 50, 100, 100], children: []},
+            ]
+        });
+
         const views = Array.from(view).map((v) => v.name);
         expect(views).toContain("root");
         expect(views).toContain("a");


### PR DESCRIPTION
- please explain why the method is wrong or fix; ideally both

I think this may explain some of the flickering we've seen in explore mode.